### PR TITLE
Use Span<lo, hi, ilk> instead of Result<>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,19 @@ pub mod tangle;
 mod code_extractor;
 use code_extractor::CodeExtractor;
 
+#[derive(Debug, PartialEq, Eq)]
+enum Ilk {
+    SectionName,
+    Unterminated(&'static str),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Span {
+    lo: usize,
+    hi: usize,
+    ilk: Ilk,
+}
+
 pub fn show_raw(text: &str) {
     // DELETEME: Just to silence dead code warnings
     let blocks = CodeExtractor::new(text);


### PR DESCRIPTION
Since error tokens aren't unexpected, we just regard Unterminated
(and future syntax error types) as just Spans to be processed in
the ordinary course of events.

Also, to disambiguate 'block' and 'section', we'll use 'block' for
a Markdown code block, and 'section' for a Knuth-like section that
can span multiple code blocks, have a name, etc.